### PR TITLE
Add Manage API Keys link to LangChain page

### DIFF
--- a/langchain/index.html
+++ b/langchain/index.html
@@ -19,7 +19,11 @@ loadMarkdown("README.md", "readmeDiv", "_parent");
 <body>
 <div class="content contentpadding large-list">
   <div id="readmeDiv"></div>
-
+  <p>
+    <a href="/localsite/tools/storage/api#gonext=/planet/langchain/trade">
+      🔑 Manage API Keys
+    </a>
+  </p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
This PR adds a new link to /localsite/tools/storage/api with a go next parameter for returning to the /planet/langchain/trade page. this allows users to manage API keys easily.